### PR TITLE
Fix a `todo!()` in `StdoutStream`.

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -419,7 +419,7 @@ impl Subscribe for ImportImplStdout {
 #[async_trait::async_trait]
 impl StdoutStream for ImportImplStdout {
     fn stream(&self) -> Box<(dyn wasmtime_wasi::preview2::HostOutputStream + 'static)> {
-        todo!()
+        Stdout.stream()
     }
 
     fn isatty(&self) -> bool {


### PR DESCRIPTION
Fix a `todo!()` that I missed in #4.