### PR TITLE
Implement printing for more types.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -270,7 +270,17 @@ fn format_function(f: &wit_parser::Function, querier: &Querier) -> String {
             format!(" -> {}", t.italic())
         }
         wit_parser::Results::Named(n) if n.is_empty() => String::new(),
-        wit_parser::Results::Named(_) => todo!(),
+        wit_parser::Results::Named(params) => {
+            let params = params
+                .iter()
+                .map(|(name, t)| {
+                    let t = querier.display_wit_type(t, Expansion::Collapsed);
+                    format!("{name}: {t}")
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" -> {params}")
+        }
     };
     format!("func({params}){rets}")
 }

--- a/src/wit.rs
+++ b/src/wit.rs
@@ -247,11 +247,12 @@ impl Querier {
                 }
                 Expansion::Collapsed => typ.name.clone().unwrap(),
             },
-            wit_parser::TypeDefKind::Resource => todo!(),
-            wit_parser::TypeDefKind::Handle(_) => todo!(),
-            wit_parser::TypeDefKind::Flags(_) => todo!(),
-            wit_parser::TypeDefKind::Future(_) => todo!(),
-            wit_parser::TypeDefKind::Stream(_) => todo!(),
+            // TODO: Fill these in with more information.
+            wit_parser::TypeDefKind::Resource => format!("resource<...>"),
+            wit_parser::TypeDefKind::Handle(_) => format!("handle<...>"),
+            wit_parser::TypeDefKind::Flags(_) => format!("flags<...>"),
+            wit_parser::TypeDefKind::Future(_) => format!("future<...>"),
+            wit_parser::TypeDefKind::Stream(_) => format!("stream<...>"),
             wit_parser::TypeDefKind::Unknown => unreachable!(),
         };
         Cow::Owned(display)


### PR DESCRIPTION
Implement printing for named function results, and change some `todo`s to return placeholder strings so that the repl is minimally usable on components with those types.