### PR TITLE
Add Makefile and document how to build/install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-.PHONY: build
-build:
-	cargo build --release
-
-.PHONY: install
-install:
-	cargo install --path . --locked

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build
+build:
+	cargo build --release
+
+.PHONY: install
+install:
+	cargo install --path . --locked

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 The WebAssembly Component repl.
 
+## Building from Source
+
+You can build `wepl` from source by running `make build`
+
+## Installing `wepl`
+
+You can install `wepl` on your local system by running `make install`
+
 ## Example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The WebAssembly Component repl.
 
 ## Building from Source
 
-You can build `wepl` from source by running `make build`
+You can build `wepl` from source by running `cargo build --release` (or `cargo build` to build in debug mode).
 
 ## Installing `wepl`
 
-You can install `wepl` on your local system by running `make install`
+You can install `wepl` on your local system by running `cargo install --path . --locked`
 
 ## Example
 


### PR DESCRIPTION
This PR adds a simple `Makefile` which allows users to `build` and `install` the `wepl` CLI locally. Additionally, building from source and installing locally has been documented in `README.md`