### PR TITLE
Resolve string idents from scope

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -240,7 +240,8 @@ impl<'a> Evaluator<'a> {
                 | component::Type::S8
                 | component::Type::S16
                 | component::Type::S32
-                | component::Type::S64 => self.lookup_in_scope(ident),
+                | component::Type::S64
+                | component::Type::String => self.lookup_in_scope(ident),
                 t => todo!("handle ident '{ident}' with type {t:?}"),
             },
             None => self.lookup_in_scope(ident),


### PR DESCRIPTION
This allows users to pass strings to function calls using local variables

```bash
wepl mymodule.wasm
World: root:component/root
> .exports
reverse: func(input: string) -> string
> foo = "bar"
foo: string
> reverse(foo)
"oof"
>
```