### PR TITLE
fix parsing multiple arg tokens

### DIFF
--- a/src/command/parser.rs
+++ b/src/command/parser.rs
@@ -235,6 +235,7 @@ impl<'a> FunctionCall<'a> {
             if input.front().map(|t| t.token()) != Some(TokenKind::Comma) {
                 break;
             }
+            input.pop_front();
         }
         expect_token(input, |t| t == TokenKind::ClosedParen)?;
         Ok(Some(FunctionCall {


### PR DESCRIPTION
The `Comma` token needs to be popped in order to move the logic forward and let the loop work on the next token.